### PR TITLE
fix: change default version from latest to 1.19.6 for cache reliability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   version:
     description: 'Q CLI version to install (e.g., latest)'
     required: false
-    default: 'latest'
+    default: '1.19.6'
   aws-region:
     description: 'AWS region for Q CLI operations'
     required: false


### PR DESCRIPTION
## Problem
Using `latest` as default causes cache mismatches when new Q CLI versions are released.

## Solution
Changed default version to `1.19.6` (current latest as of 2025-11-15).

## Impact
- ✅ Cache keys now use fixed version: `q-1.19.6-Linux-X64`
- ✅ Reliable cache hits (no more mismatches)
- ✅ Users without explicit version get tested stable version
- ✅ Users can still override with `version: 'latest'` if desired

## Changes
- **1 file changed:** action.yml (line 9 only)
- **1 commit:** Clean branch from main

**Related:** Part of version management automation plan