### PR TITLE
chore: make Q CLI test workflow manual-only

### DIFF
--- a/.github/workflows/test-q-cli.yml
+++ b/.github/workflows/test-q-cli.yml
@@ -1,10 +1,6 @@
 name: Test Q CLI Usage
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Changes Q CLI test workflow to manual trigger only to save AWS costs.

## Changes

Removed automatic triggers:
- ❌ `push: branches: [main]`
- ❌ `pull_request: branches: [main]`
- ✅ `workflow_dispatch:` (kept - manual trigger)

## Why

- The Q CLI test workflow consumes AWS resources (OIDC authentication, Q CLI API calls)
- It was created for testing purposes, not continuous validation
- The main action tests (`test.yml`) already validate core functionality
- Manual triggering is sufficient for Q CLI integration testing

## How to Run

**Via GitHub UI:**
1. Go to Actions → Test Q CLI Usage
2. Click "Run workflow"

**Via CLI:**
```bash
gh workflow run "Test Q CLI Usage"
```

## Impact

- ✅ Saves AWS costs (no automatic runs)
- ✅ Workflow still available when needed
- ✅ No impact on main action tests (test.yml still runs automatically)