### PR TITLE
Add deprecation notice pointing to setup-kiro-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # Setup Q CLI Action
 
+> [!WARNING]
+> **DEPRECATED:** Amazon Q Developer CLI has been rebranded to Kiro CLI. Please migrate to [setup-kiro-action](https://github.com/clouatre-labs/setup-kiro-action).
+>
+> ```yaml
+> # Before (deprecated)
+> - uses: clouatre-labs/setup-q-cli-action@v1
+> - run: qchat chat --no-interactive "prompt"
+>
+> # After (recommended)
+> - uses: clouatre-labs/setup-kiro-action@v1
+> - run: kiro-cli-chat chat --no-interactive "prompt"
+> ```
+>
+> This action will continue to work but will not receive updates.
+
 [![Test Action](https://github.com/clouatre-labs/setup-q-cli-action/actions/workflows/test.yml/badge.svg)](https://github.com/clouatre-labs/setup-q-cli-action/actions/workflows/test.yml)
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Setup%20Q%20CLI-blue.svg?colorA=24292e&colorB=0366d6&style=flat&longCache=true&logo=github)](https://github.com/marketplace/actions/setup-q-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,11 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Deprecation warning
+      shell: bash
+      run: |
+        echo "::warning::DEPRECATED: This action is deprecated. Amazon Q Developer CLI has been rebranded to Kiro CLI. Please migrate to clouatre-labs/setup-kiro-action. See https://github.com/clouatre-labs/setup-kiro-action#migration-from-q-cli"
+
     - name: Check platform support
       shell: bash
       run: |


### PR DESCRIPTION
## Summary

Amazon Q Developer CLI has been rebranded to Kiro CLI. This PR adds deprecation notices to guide users to the new action.

## Changes

- **README.md**: Added `[!WARNING]` banner with migration instructions
- **action.yml**: Added deprecation warning step that emits `::warning::` in workflow logs

## Migration Path

```yaml
# Before (deprecated)
- uses: clouatre-labs/setup-q-cli-action@v1
- run: qchat chat --no-interactive "prompt"

# After (recommended)
- uses: clouatre-labs/setup-kiro-action@v1
- run: kiro-cli-chat chat --no-interactive "prompt"
```

## Related

- New action: https://github.com/clouatre-labs/setup-kiro-action
- Marketplace: https://github.com/marketplace/actions/setup-kiro-cli