### PR TITLE
feat: add Renovate config for automated version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^action\\.yml$"],
+      "matchStrings": [
+        "default:\\s*['\"](?<currentValue>\\d+\\.\\d+\\.\\d+)['\"]"
+      ],
+      "depNameTemplate": "aws/amazon-q-developer-cli",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Renovate to automate Q CLI version updates.

**Problem**: Custom `check-version.yml` workflow failing (run 19817933034). Version outdated (1.19.6 vs 1.19.7).

**Solution**: Use Renovate with regex manager to track `aws/amazon-q-developer-cli` releases.

**Changes**:
- Added `renovate.json` with custom regex manager
- Tracks `aws/amazon-q-developer-cli` releases
- Matches version in `action.yml` default field
- Preserves YAML formatting

**Test**: Renovate should immediately detect 1.19.6 → 1.19.7 update and create PR.