### PR TITLE
chore: remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"


### PR DESCRIPTION
Removes redundant configuration.

**Removed:**
- `.github/dependabot.yml` - Renovate handles GitHub Actions updates

**Why:** Consolidating on Renovate for all dependency updates.