### PR TITLE
chore(ci): pin ubuntu runner and group renovate updates

### DIFF
--- a/.github/workflows/test-q-cli.yml
+++ b/.github/workflows/test-q-cli.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   test-q-cli-tier1:
     name: Test Q CLI - Tier 1 (Maximum Security)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -56,7 +56,7 @@ jobs:
 
   test-q-cli-tier2:
     name: Test Q CLI - Tier 2 (Balanced Security)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     steps:
       - name: Checkout
@@ -110,7 +110,7 @@ jobs:
 
   test-q-cli-multiple-prompts:
     name: Test Q CLI - Multiple Prompts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   test-ubuntu-x64:
     name: Test on Ubuntu x64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -38,7 +38,7 @@ jobs:
 
   test-cache:
     name: Test caching
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -62,7 +62,7 @@ jobs:
 
   test-sigv4-config:
     name: Test SIGV4 configuration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -89,7 +89,7 @@ jobs:
 
   test-checksum-verification:
     name: Test SHA256 verification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/renovate.json
+++ b/renovate.json
@@ -1,21 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices"
-  ],
+  "extends": ["config:best-practices"],
+  "labels": ["dependencies"],
+  "minimumReleaseAge": "3 days",
   "platformAutomerge": true,
-  "labels": [
-    "dependencies"
-  ],
   "dependencyDashboard": false,
+  "schedule": ["before 6am on monday"],
   "packageRules": [
     {
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch"
-      ],
-      "automerge": true
+      "groupName": "non-major",
+      "matchUpdateTypes": ["patch", "minor", "digest", "pin", "lockFileMaintenance"],
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "groupName": "github-actions",
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "platformAutomerge": true
     }
   ]
 }


### PR DESCRIPTION
Pins ubuntu-latest to ubuntu-24.04 for deterministic builds. Groups Renovate patch/minor/digest into single weekly PR to minimize CI runs.