### PR TITLE
ci: pin runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/test-q-cli.yml
+++ b/.github/workflows/test-q-cli.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   test-q-cli-tier1:
     name: Test Q CLI - Tier 1 (Maximum Security)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -56,7 +56,7 @@ jobs:
 
   test-q-cli-tier2:
     name: Test Q CLI - Tier 2 (Balanced Security)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     steps:
       - name: Checkout
@@ -112,7 +112,7 @@ jobs:
 
   test-q-cli-multiple-prompts:
     name: Test Q CLI - Multiple Prompts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   test-ubuntu-x64:
     name: Test on Ubuntu x64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -45,7 +45,7 @@ jobs:
 
   test-cache:
     name: Test caching
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -69,7 +69,7 @@ jobs:
 
   test-sigv4-config:
     name: Test SIGV4 configuration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -96,7 +96,7 @@ jobs:
 
   test-checksum-verification:
     name: Test SHA256 verification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
Pin ubuntu-latest to ubuntu-24.04 for deterministic CI environments.

## Changes
- `.github/workflows/test.yml`: `ubuntu-latest` → `ubuntu-24.04` (all occurrences)
- `.github/workflows/test-q-cli.yml`: `ubuntu-latest` → `ubuntu-24.04` (all occurrences)

## Motivation
Unversioned runner aliases drift silently; pinning ensures reproducible builds.