### PR TITLE
fix(ci): correct zizmor min-severity value (error -> high)

### DIFF
--- a/.github/workflows/test-q-cli.yml
+++ b/.github/workflows/test-q-cli.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write  # zizmor: ignore[overly-broad-permissions]
+  id-token: write  # zizmor: ignore[excessive-permissions]
   contents: read
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           advanced-security: false
           annotations: true
-          min-severity: error
+          min-severity: high
 
   ci-result:
     name: CI Result

--- a/action.yml
+++ b/action.yml
@@ -64,8 +64,8 @@ runs:
       id: install
       if: steps.cache-q.outputs.cache-hit != 'true'
       shell: bash
-      run: |
-        echo "::group::Installing Q CLI ${{ inputs.version }}"  # zizmor: ignore[template-injection]
+      run: | # zizmor: ignore[template-injection]
+        echo "::group::Installing Q CLI ${{ inputs.version }}"
         mkdir -p ~/.local/bin
         
         # Determine architecture
@@ -80,7 +80,7 @@ runs:
         fi
         
         # AWS CDN expects version without 'v' prefix (e.g., '1.19.6' not 'v1.19.6')
-        VERSION="${{ inputs.version }}"  # zizmor: ignore[template-injection]
+        VERSION="${{ inputs.version }}"
         # Strip 'v' prefix if present
         VERSION="${VERSION#v}"
         
@@ -92,7 +92,7 @@ runs:
         curl --proto '=https' --tlsv1.2 -sSfL "$DOWNLOAD_URL" -o q.zip
         
         # Verify checksum if requested
-        if [ "${{ inputs.verify-checksum }}" = "true" ]; then  # zizmor: ignore[template-injection]
+        if [ "${{ inputs.verify-checksum }}" = "true" ]; then
           echo "Downloading SHA256 checksum..."
           curl --proto '=https' --tlsv1.2 -sSfL "${DOWNLOAD_URL}.sha256" -o q.zip.sha256
           
@@ -113,7 +113,7 @@ runs:
           ACTUAL_VERSION=$(grep '^BUILD_VERSION=' q/BUILD-INFO | cut -d= -f2)
           echo "version=${ACTUAL_VERSION}" >> $GITHUB_OUTPUT
         else
-          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT  # zizmor: ignore[template-injection]
+          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
         fi
         
         # Copy only qchat binary (sufficient for CI/CD)
@@ -128,16 +128,16 @@ runs:
     - name: Setup PATH
       id: setup-path
       shell: bash
-      run: |
-        echo "$HOME/.local/bin" >> $GITHUB_PATH  # zizmor: ignore[dangerous-write]
+      run: | # zizmor: ignore[github-env]
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
         echo "path=$HOME/.local/bin" >> $GITHUB_OUTPUT
 
     - name: Configure SIGV4 authentication
       if: inputs.enable-sigv4 == 'true'
       shell: bash
-      run: |
-        echo "AMAZON_Q_SIGV4=true" >> $GITHUB_ENV  # zizmor: ignore[dangerous-write]
-        echo "AWS_REGION=${{ inputs.aws-region }}" >> $GITHUB_ENV  # zizmor: ignore[template-injection]
+      run: | # zizmor: ignore[github-env,template-injection]
+        echo "AMAZON_Q_SIGV4=true" >> $GITHUB_ENV
+        echo "AWS_REGION=${{ inputs.aws-region }}" >> $GITHUB_ENV
 
     - name: Verify installation
       shell: bash


### PR DESCRIPTION
## Summary

Fixes CI broken by #53 (`chore(ci): add zizmor SHA-pinning enforcement`), which introduced three zizmor issues:

1. `min-severity: error` is not a valid zizmor value — corrected to `min-severity: high`
2. `# zizmor: ignore[...]` comments placed on lines inside `run: |` blocks — zizmor only reads the opening `run: |` line; moved all ignores there
3. Wrong rule names: `dangerous-write` → `github-env`; `overly-broad-permissions` → `excessive-permissions`

## Changes

- `.github/workflows/test.yml` — `min-severity: error` → `high`
- `.github/workflows/test-q-cli.yml` — fix rule name `overly-broad-permissions` → `excessive-permissions`
- `action.yml` — move inline ignores to `run: |` opening lines; fix rule names; combine multiple rules per step where needed

## Test plan

- [ ] zizmor job passes
- [ ] No other CI jobs affected