### PR TITLE
chore: deprecate action - upstream aws/amazon-q-developer-cli archived by AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Setup Q CLI Action
 
 > [!WARNING]
-> **DEPRECATED:** Amazon Q Developer CLI has been rebranded to Kiro CLI. Please migrate to [setup-kiro-action](https://github.com/clouatre-labs/setup-kiro-action).
+> **This action is deprecated.** The upstream [`aws/amazon-q-developer-cli`](https://github.com/aws/amazon-q-developer-cli) has been **archived by AWS**.
+> Migrate to [`clouatre-labs/setup-kiro-action`](https://github.com/clouatre-labs/setup-kiro-action), based on the replacement Kiro tooling.
 >
 > ```yaml
 > # Before (deprecated)

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Deprecation warning
       shell: bash
       run: |
-        echo "::warning::DEPRECATED: This action is deprecated. Amazon Q Developer CLI has been rebranded to Kiro CLI. Please migrate to clouatre-labs/setup-kiro-action. See https://github.com/clouatre-labs/setup-kiro-action#migration-from-q-cli"
+        echo "::warning title=Action Deprecated::This action is deprecated. The upstream aws/amazon-q-developer-cli has been archived by AWS. Migrate to https://github.com/clouatre-labs/setup-kiro-action"
 
     - name: Check platform support
       shell: bash


### PR DESCRIPTION
## Summary

Deprecates this action now that the upstream [`aws/amazon-q-developer-cli`](https://github.com/aws/amazon-q-developer-cli) has been archived by AWS.

## Changes

- `README.md`: Update deprecation notice to reference the upstream archival by AWS (not just a rebrand)
- `action.yml`: Strengthen the runtime `::warning::` annotation with a `title` field and explicit upstream archival message

## Migration

Users should migrate to [`clouatre-labs/setup-kiro-action`](https://github.com/clouatre-labs/setup-kiro-action).

## Post-merge

After merge, archive this repository via Settings -> Danger Zone -> Archive.