### PR TITLE
chore: migrate license from MIT to Apache 2.0

### DIFF
--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,5 +1,3 @@
-Copyright 2025-2026 Hugues Clouatre
-
 Apache License
 Version 2.0, January 2004
 http://www.apache.org/licenses/
@@ -52,7 +50,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
 
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
 
 END OF TERMS AND CONDITIONS
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [![Test Action](https://github.com/clouatre-labs/setup-q-cli-action/actions/workflows/test.yml/badge.svg)](https://github.com/clouatre-labs/setup-q-cli-action/actions/workflows/test.yml)
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Setup%20Q%20CLI-blue.svg?colorA=24292e&colorB=0366d6&style=flat&longCache=true&logo=github)](https://github.com/marketplace/actions/setup-q-cli)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Latest Release](https://img.shields.io/github/v/release/clouatre-labs/setup-q-cli-action)](https://github.com/clouatre-labs/setup-q-cli-action/releases/latest)
 
 GitHub Action to install and cache [Amazon Q Developer CLI](https://github.com/aws/amazon-q-developer-cli) (now [Kiro CLI](https://kiro.dev/docs/cli/)) for use in workflows.
@@ -330,7 +330,7 @@ Contributions are welcome! Please open an issue or PR.
 
 ## License
 
-MIT - See [LICENSE](LICENSE)
+Apache 2.0. See [LICENSE](LICENSE).
 
 ## Related
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[[annotations]]
+path = ["*.yml", "*.yaml", "*.md", "*.json", "*.sh", "examples/**/*", ".github/**/*", "LICENSE", "LICENSES/**/*", "SECURITY*"]
+precedence = "override"
+SPDX-FileCopyrightText = "2025-2026 Hugues Clouatre"
+SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
## Summary

Migrates the project license from MIT to Apache 2.0, consistent with the rest of the clouatre-labs organization.

## Changes

- `LICENSE` -- replaced MIT text with Apache 2.0
- `LICENSES/Apache-2.0.txt` -- added REUSE-compliant license file
- `REUSE.toml` -- added SPDX/REUSE annotations
- `README.md` -- updated license badge and section text

## Test plan

- [ ] All license file references updated
- [ ] Badge renders correctly