### PR TITLE
chore(docs): pin setup-q-cli-action refs to SHA instead of tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 >
 > ```yaml
 > # Before (deprecated)
-> - uses: clouatre-labs/setup-q-cli-action@v1
+> - uses: clouatre-labs/setup-q-cli-action@77815c314407491b506960825dc8bd8fa517ce60  # v1.0.2
 > - run: qchat chat --no-interactive "prompt"
 >
 > # After (recommended)
@@ -57,7 +57,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Setup Q CLI
-        uses: clouatre-labs/setup-q-cli-action@v1
+        uses: clouatre-labs/setup-q-cli-action@77815c314407491b506960825dc8bd8fa517ce60  # v1.0.2
         with:
           enable-sigv4: true
           aws-region: us-east-1
@@ -182,7 +182,7 @@ permissions:
     role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
     aws-region: us-east-1
 
-- uses: clouatre-labs/setup-q-cli-action@v1
+- uses: clouatre-labs/setup-q-cli-action@77815c314407491b506960825dc8bd8fa517ce60  # v1.0.2
   with:
     enable-sigv4: true  # Required with OIDC
 ```
@@ -198,7 +198,7 @@ permissions:
 For local testing or non-GitHub CI/CD environments.
 
 ```yaml
-- uses: clouatre-labs/setup-q-cli-action@v1
+- uses: clouatre-labs/setup-q-cli-action@77815c314407491b506960825dc8bd8fa517ce60  # v1.0.2
   # Do NOT set enable-sigv4 with long-lived credentials
 
 - name: Use Q CLI
@@ -216,7 +216,7 @@ For local testing or non-GitHub CI/CD environments.
 ### Pin to Specific Version
 
 ```yaml
-- uses: clouatre-labs/setup-q-cli-action@v1
+- uses: clouatre-labs/setup-q-cli-action@77815c314407491b506960825dc8bd8fa517ce60  # v1.0.2
   with:
     version: '1.18.0'  # Use any specific version
     verify-checksum: true  # Recommended for production
@@ -228,7 +228,7 @@ This action defaults to a tested version that's automatically updated weekly.
 
 **Pin to a specific version:**
 ```yaml
-- uses: clouatre-labs/setup-q-cli-action@v1
+- uses: clouatre-labs/setup-q-cli-action@77815c314407491b506960825dc8bd8fa517ce60  # v1.0.2
   with:
     version: '1.18.0'
 ```
@@ -261,7 +261,7 @@ Example: `q-latest-Linux-X64`
 Ensure you're using the action before attempting to run `qchat`:
 
 ```yaml
-- uses: clouatre-labs/setup-q-cli-action@v1
+- uses: clouatre-labs/setup-q-cli-action@77815c314407491b506960825dc8bd8fa517ce60  # v1.0.2
 - run: qchat --version  # This will work
 ```
 

--- a/examples/tier1-maximum-security.yml
+++ b/examples/tier1-maximum-security.yml
@@ -22,7 +22,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Setup Q CLI
-        uses: clouatre-labs/setup-q-cli-action@v1
+        uses: clouatre-labs/setup-q-cli-action@77815c314407491b506960825dc8bd8fa517ce60  # v1.0.2
         with:
           enable-sigv4: true
           aws-region: us-east-1

--- a/examples/tier2-balanced-security.yml
+++ b/examples/tier2-balanced-security.yml
@@ -22,7 +22,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Setup Q CLI
-        uses: clouatre-labs/setup-q-cli-action@v1
+        uses: clouatre-labs/setup-q-cli-action@77815c314407491b506960825dc8bd8fa517ce60  # v1.0.2
         with:
           enable-sigv4: true
           aws-region: us-east-1

--- a/examples/tier3-advanced-patterns.yml
+++ b/examples/tier3-advanced-patterns.yml
@@ -24,7 +24,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Setup Q CLI
-        uses: clouatre-labs/setup-q-cli-action@v1
+        uses: clouatre-labs/setup-q-cli-action@77815c314407491b506960825dc8bd8fa517ce60  # v1.0.2
         with:
           enable-sigv4: true
           aws-region: us-east-1


### PR DESCRIPTION
## Summary

Pin all \`clouatre-labs/setup-q-cli-action\` references in README.md and examples/ from tag-based refs (\`@v1\`) to full commit SHA refs for supply-chain integrity. Follows the same pattern applied in setup-kiro-action PR #54.

kiro-cli does not support \`AMAZON_Q_SIGV4\`, so there is no viable replacement for the GitHub Action at this time. Pinning to SHA is the correct hardening step while the situation is documented.

## Changes

- \`README.md\` -- 7 occurrences updated (including the deprecated example block)
- \`examples/tier1-maximum-security.yml\` -- 1 occurrence updated
- \`examples/tier2-balanced-security.yml\` -- 1 occurrence updated
- \`examples/tier3-advanced-patterns.yml\` -- 1 occurrence updated

**Before:** \`uses: clouatre-labs/setup-q-cli-action@v1\`
**After:** \`uses: clouatre-labs/setup-q-cli-action@77815c314407491b506960825dc8bd8fa517ce60  # v1.0.2\`

## Test plan

- [x] Zero \`@v1\` refs remain in README.md and examples/
- [x] All 10 replacements use full 40-char SHA with two spaces before \`#\` and inline version comment
- [x] \`.github/workflows/\` untouched (already SHA-pinned)
- [x] No third-party action refs changed
- [x] YAML and Markdown syntax valid