### PR TITLE
chore(docs): pin setup-kiro-action ref to SHA instead of tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > - run: qchat chat --no-interactive "prompt"
 >
 > # After (recommended)
-> - uses: clouatre-labs/setup-kiro-action@v1
+> - uses: clouatre-labs/setup-kiro-action@91393ee22956aee30d31f53abc8d37ac69e02102  # v1.0.1
 > - run: kiro-cli-chat chat --no-interactive "prompt"
 > ```
 >


### PR DESCRIPTION
## Summary

Pins the one remaining \`setup-kiro-action@v1\` ref in README.md to the full commit SHA for supply-chain security, following the same pattern applied in setup-kiro-action PR #54 and in the previous PR on this repo.

## Changes

- \`README.md\`: replace \`clouatre-labs/setup-kiro-action@v1\` with \`clouatre-labs/setup-kiro-action@91393ee22956aee30d31f53abc8d37ac69e02102  # v1.0.1\`

## Notes

The floating \`v1\` tag on setup-kiro-action resolves to \`v1.0.0\`, not \`v1.0.1\`. This change correctly pins to the latest release (\`v1.0.1\`), consistent with supply-chain pinning best practices.

## Test plan

- [x] grep confirms zero \`setup-kiro-action@v\` refs remain
- [x] SHA independently verified against \`refs/tags/v1.0.1\` via \`git ls-remote\`
- [x] Markdown blockquote intact