### PR TITLE
ci: align workflows with aptu v0.8.1 canonical reference

### DIFF
--- a/.github/instructions/pr-review.md
+++ b/.github/instructions/pr-review.md
@@ -1,30 +1,35 @@
 # PR Review Instructions
 
+## Grounding rules
+
+- Only flag issues you can cite directly from the diff. If you cannot point to a specific line,
+  do not raise the comment.
+- If you are unsure whether something is a bug or intentional, say so explicitly rather than
+  asserting it is wrong.
+- Do not apply general knowledge about Rust, rmcp, or GitHub Actions if the diff does not
+  contain evidence of a violation. Patterns and invariants are documented in `AGENTS.md`; cite
+  that file if you reference a rule.
+
 ## Scope
 
 Review only what the PR changes. Do not flag issues in files the PR does not touch.
 
+## Rust crates
+
+- Do not flag `.unwrap()` in test code; it is acceptable there.
+- Do not suggest adding dependencies without a justification visible in the diff.
+- Do not comment on style that `cargo fmt` or `cargo clippy` would catch automatically; those
+  are enforced by CI.
+
 ## Workflow files
 
-When reviewing `.github/workflows/` changes:
-
-- Evaluate the full job context, not individual steps in isolation. A step that installs a binary
-  and a step that executes it are part of the same job; verify both exist before flagging a
-  missing publish or execution command.
-- Flag `${{ expression }}` interpolation directly inside `run:` scripts as an injection risk;
-  inputs should be passed via `env:` blocks.
+- Flag `${{ expression }}` interpolation directly inside `run:` scripts; inputs should be
+  passed via `env:` blocks.
 - Verify action pins use commit SHAs, not mutable tags.
 - Check that `permissions:` blocks are present and minimal.
-
-## action.yml / composite actions
-
-- Verify new inputs have a `description` field.
-- Do not flag missing `default:` on required inputs; required inputs have no default by design.
 
 ## General
 
 - One comment per distinct issue; do not duplicate findings across multiple inline comments.
-- Prefer suggesting a fix (suggestion block) over describing the problem when the fix is
-  unambiguous.
-- Do not comment on code style that linters or formatters catch automatically; those are enforced
-  by CI.
+- Prefer a suggestion block over describing the problem when the fix is unambiguous.
+- If you have no findings, say so. Do not invent issues to appear thorough.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -8,18 +8,19 @@ on:
 permissions: {}
 
 jobs:
-  review:
+  label:
     runs-on: ubuntu-24.04-arm
     permissions:
       pull-requests: write
       issues: write
       contents: read
+      attestations: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Review PR
-        uses: clouatre-labs/aptu@cb08760ef7f38176359a4b1713297cced31b76f5 # v0.7.0
+        uses: clouatre-labs/aptu@475e47a210fc7c10bf9a5a4d453c0eeb0e97f9fc # v0.8.1
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -28,7 +29,8 @@ jobs:
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           provider: gemini
           model: gemini-3.1-flash-lite-preview
-          fallback-provider: openrouter
-          fallback-model: inception/mercury-2
+          skip-labeled: 'false'
+          fallback-provider: 'openrouter'
+          fallback-model: 'inception/mercury-2'
           instructions-file: .github/instructions/pr-review.md
           repo-path: ${{ github.workspace }}


### PR DESCRIPTION
## Summary

Aligns GitHub Actions workflows with the aptu v0.8.1 canonical reference established in aptu-coder.

## Changes

- `.github/workflows/pr-review.yml` -- bump aptu to v0.8.1 SHA, add `attestations: read` permission, add missing inputs
- `.github/instructions/pr-review.md` -- replace with canonical 35-line grounding-rules version
