### PR TITLE
chore(ci): bump clouatre-labs/aptu action to v0.10.1

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Review PR
-        uses: clouatre-labs/aptu@93ca6d6613ebc2bb47f92caf48d10509ad0920e3 # v0.8.6
+        uses: clouatre-labs/aptu@5545c56f0f4bf52a3dc918ec48a56c309280447c # v0.10.1
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bumps `clouatre-labs/aptu` GitHub Action from v0.8.6 to v0.10.1.

SHA pin: `5545c56f0f4bf52a3dc918ec48a56c309280447c`

Release: https://github.com/clouatre-labs/aptu/releases/tag/v0.10.1
